### PR TITLE
Security Fix for #136

### DIFF
--- a/chrome/content/calendar-calendars-list.js
+++ b/chrome/content/calendar-calendars-list.js
@@ -139,7 +139,7 @@ exchCalPopUpMenu.prototype = {
 			var mailbox = { value: exchWebServicesIdentityprefs.getCharPref("useremail")};
 		}
 		else {
-			var mailbox = { value: "someone@somewhere.com"};
+			var mailbox = { value: "null@null"};
 		}
 
 		if (prompts.prompt(null, "Convert Calendar", "Do you want to convert this calendar '"+calName+"' to the new Exchange 2007/2010 Calendar and Tasks add-on? If YES please enter the primarySMTP emailaddress:", mailbox, "", {}))  {

--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -4885,7 +4885,7 @@ if (this.debug) this.logInfo(" ;;;; rrule:"+rrule.icalProperty.icalString);
 						mailbox.addChildTag("EmailAddress", "nsTypes", tmpEmailAddress);
 					}
 					else {
-						mailbox.addChildTag("EmailAddress", "nsTypes", "unknown@somewhere.com");
+						mailbox.addChildTag("EmailAddress", "nsTypes", "null@null");
 					}
 					if (attendee.role != "CHAIR") {
 						ae.addChildTag("ResponseType", "nsTypes", attendeeStatus[attendee.participationStatus]);

--- a/interfaces/exchangeEvent/mivExchangeEvent.js
+++ b/interfaces/exchangeEvent/mivExchangeEvent.js
@@ -533,7 +533,7 @@ catch(err){
 							mailbox.addChildTag("EmailAddress", "t", tmpEmailAddress);
 						}
 						else {
-							mailbox.addChildTag("EmailAddress", "t", "unknown@somewhere.com");
+							mailbox.addChildTag("EmailAddress", "t", "null@null");
 						}
 						ae.addChildTag("ResponseType", "t", attendeeStatus[attendee.participationStatus]);
 


### PR DESCRIPTION
Changed unknown@somewhere.com to null@null, as the former leaks
information to a valid domain.

unknown@somewhere.com results in a delivery failure, as also will
null@null, but if the owners of somewhere.com set up an email, they get
everyone's invites, which could contain private data.