### PR TITLE
AddressBook: get the right username for address books

### DIFF
--- a/interfaces/exchangeAddressBook/exchangeAbDistListDirectory/exchangeAbDistListDirectory.js
+++ b/interfaces/exchangeAddressBook/exchangeAbDistListDirectory/exchangeAbDistListDirectory.js
@@ -999,7 +999,18 @@ exchangeAbDistListDirectory.prototype = {
 	},
 
 	get user() {
-		return this.domain+"\\"+exchWebService.commonFunctions.safeGetCharPref(this.prefs, "user", "");
+		var username = exchWebService.commonFunctions.safeGetCharPref(this.prefs, "user", "");
+		if (username.indexOf("@") > -1) {
+			return username;
+		}
+		else {
+			if (this.domain == "") {
+				return exchWebService.commonFunctions.safeGetCharPref(this.prefs, "user", "");
+			}
+			else {
+				return this.domain+"\\"+exchWebService.commonFunctions.safeGetCharPref(this.prefs, "user", "");
+			}
+		}
 	},
 
 	set user(value) {

--- a/interfaces/exchangeAddressBook/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
+++ b/interfaces/exchangeAddressBook/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
@@ -1126,7 +1126,18 @@ try {
 	},
 
 	get user() {
-		return this.domain+"\\"+exchWebService.commonFunctions.safeGetCharPref(this.prefs, "user", "");
+		var username = exchWebService.commonFunctions.safeGetCharPref(this.prefs, "user", "");
+		if (username.indexOf("@") > -1) {
+			return username;
+		}
+		else {
+			if (this.domain == "") {
+				return exchWebService.commonFunctions.safeGetCharPref(this.prefs, "user", "");
+			}
+			else {
+				return this.domain+"\\"+exchWebService.commonFunctions.safeGetCharPref(this.prefs, "user", "");
+			}
+		}
 	},
 
 	set user(value) {


### PR DESCRIPTION
when the user setting is the user mail and the domain setting is empty (fix #325 and #290)

Before this patch, when the username is `trim@example.com` the code returns `\trim@example.com` (with extra `\` at first position) instead of `trim@example.com`.