### PR TITLE
Enabled editing server address box

### DIFF
--- a/chrome/content/manageEWSAccounts.xul
+++ b/chrome/content/manageEWSAccounts.xul
@@ -63,7 +63,7 @@
 					<exchWebService-statusImage id="exchWebService_server_status"/>
 				    <vbox>
 			            	<textbox id="exchWebService_server"
-						disabled="true" 
+						disabled="false" 
 			                  	required="true" oninput="exchWebService.manageEWSAccounts.doServerChanged(this);" 
 						placeholder="https://ews.example.com/ews/exchange.asmx"/>
 				    </vbox>


### PR DESCRIPTION
My first steps on this one so treading gently :)
Could not add the address of the office365 server as the address box was disabled. Enabled in the least intrusive way I could think of  and I have it up and running now.
