### PR TITLE
Thunderbird hangs on startup 

### DIFF
--- a/interfaces/exchangeCalendar/mivExchangeCalendar.js
+++ b/interfaces/exchangeCalendar/mivExchangeCalendar.js
@@ -8578,7 +8578,7 @@ else {
 
 			while (!doStop) {
 
-				if ((startYear == endYear) && (startYearDay == endYearDay)) {
+				if ((startYear >= endYear) && (startYearDay >= endYearDay)) {
 					doStop= true;
 				}
 


### PR DESCRIPTION
Be more defensive about terminating the loop when removing items from the startDate index.  Apparently under some circumstances, startYearDay (and I presume startYear) can be greater than endYear[Day]
on entry to the loop, resulting in an infinite loop and a UI hang.   Bug seen in an Office365 connection.