### PR TITLE
erFindCalendarItems code improvement (instead of PagedItemView)

### DIFF
--- a/components/erFindCalendarItems.js
+++ b/components/erFindCalendarItems.js
@@ -253,11 +253,7 @@ exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue
 					exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Last item not in range so going for another run.");
 					//exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Last item not in range so going for another run.\n\n");
 					if (this.mCbOk) {
-						var occurrenceList = [];
-						for (var index in this.occurrences) {
-							occurrenceList.push(this.occurrences[index]);
-						}
-						this.mCbOk(this, this.ids, occurrenceList);
+						this.mCbOk(this, this.ids, occurrences.slice());
 					}
 					this.recurringMasters = [];
 					this.occurrences = [];
@@ -294,11 +290,7 @@ exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue
 		}
 		else {
 			if (this.mCbOk) {
-				var occurrenceList = [];
-				for (var index in this.occurrences) {
-					occurrenceList.push(this.occurrences[index]);
-				}
-				this.mCbOk(this, this.ids, occurrenceList);
+				this.mCbOk(this, this.ids, occurrences.slice());
 			}
 			this.ids = null;
 			this.occurrences = null;

--- a/components/erFindCalendarItems.js
+++ b/components/erFindCalendarItems.js
@@ -193,9 +193,10 @@ erFindCalendarItemsRequest.prototype = {
 					var calendarItems = xml2json.XPath(rootFolder, "/t:Items/t:CalendarItem");
 					this.newStartDate = null;
 					for (var index=0; index < calendarItems.length; index++) {
+						var calItem = calendarItems[index];
 
-						if (xml2json.getTagValue(calendarItems[index], "t:Start").substr(0,10) == xml2json.getTagValue(calendarItems[index], "t:End").substr(0,10)) {
-							var tmpDateStr = xml2json.getTagValue(calendarItems[index], "t:End");
+						if (xml2json.getTagValue(calItem, "t:Start").substr(0,10) == xml2json.getTagValue(calItem, "t:End").substr(0,10)) {
+							var tmpDateStr = xml2json.getTagValue(calItem, "t:End");
 							var tmpDateObj = cal.fromRFC3339(tmpDateStr, exchWebService.commonFunctions.ecTZService().UTC).getInTimezone(exchWebService.commonFunctions.ecDefaultTimeZone());
 							var offset = cal.createDuration();
 							offset.seconds = 1;
@@ -205,38 +206,38 @@ erFindCalendarItemsRequest.prototype = {
 						}
 
 						this.itemsFound++;
-						var uid = xml2json.getTagValue(calendarItems[index], "t:UID", "");
+						var uid = xml2json.getTagValue(calItem, "t:UID", "");
 
-/*exchWebService.commonFunctions.LOG("  ** title:"+xml2json.getTagValue(calendarItems[index], "t:Subject", "<NOP>")+"\n");
-exchWebService.commonFunctions.LOG("  ** Start:"+xml2json.getTagValue(calendarItems[index], "t:Start", "<NOP>")+"\n");
-exchWebService.commonFunctions.LOG("  ** End:"+xml2json.getTagValue(calendarItems[index], "t:End", "<NOP>")+"\n");
-exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue(calendarItems[index], "t:CalendarItemType", "<NOP>")+"\n");*/
+/*exchWebService.commonFunctions.LOG("  ** title:"+xml2json.getTagValue(calItem, "t:Subject", "<NOP>")+"\n");
+exchWebService.commonFunctions.LOG("  ** Start:"+xml2json.getTagValue(calItem, "t:Start", "<NOP>")+"\n");
+exchWebService.commonFunctions.LOG("  ** End:"+xml2json.getTagValue(calItem, "t:End", "<NOP>")+"\n");
+exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue(calItem, "t:CalendarItemType", "<NOP>")+"\n");*/
 
-						switch (xml2json.getTagValue(calendarItems[index], "t:CalendarItemType")) {
+						switch (xml2json.getTagValue(calItem, "t:CalendarItemType")) {
 							case "Occurrence" :
 							case "Exception" :
 								if ((this.uid) && (this.uid != uid)) { // Do not select items which do not fit the selected uid.
 									uid = "";
 								}
 								if (uid != "") {
-									this.occurrences[uid] = {Id: xml2json.getAttributeByTag(calendarItems[index], "t:ItemId","Id"),
-										  ChangeKey: xml2json.getAttributeByTag(calendarItems[index], "t:ItemId", "ChangeKey"),
-										  type: xml2json.getTagValue(calendarItems[index], "t:CalendarItemType"),
+									this.occurrences[uid] = {Id: xml2json.getAttributeByTag(calItem, "t:ItemId","Id"),
+										  ChangeKey: xml2json.getAttributeByTag(calItem, "t:ItemId", "ChangeKey"),
+										  type: xml2json.getTagValue(calItem, "t:CalendarItemType"),
 										  uid: uid,
-										  start: xml2json.getTagValue(calendarItems[index], "t:Start"),
-										  end: xml2json.getTagValue(calendarItems[index], "t:End")};
+										  start: xml2json.getTagValue(calItem, "t:Start"),
+										  end: xml2json.getTagValue(calItem, "t:End")};
 								}
 							case "RecurringMaster" :
 							case "Single" :
-								this.ids.push({Id: xml2json.getAttributeByTag(calendarItems[index], "t:ItemId","Id"),
-										  ChangeKey: xml2json.getAttributeByTag(calendarItems[index], "t:ItemId", "ChangeKey"),
-										  type: xml2json.getTagValue(calendarItems[index], "t:CalendarItemType"),
+								this.ids.push({Id: xml2json.getAttributeByTag(calItem, "t:ItemId","Id"),
+										  ChangeKey: xml2json.getAttributeByTag(calItem, "t:ItemId", "ChangeKey"),
+										  type: xml2json.getTagValue(calItem, "t:CalendarItemType"),
 										  uid: uid,
-										  start: xml2json.getTagValue(calendarItems[index], "t:Start"),
-										  end: xml2json.getTagValue(calendarItems[index], "t:End")});
+										  start: xml2json.getTagValue(calItem, "t:Start"),
+										  end: xml2json.getTagValue(calItem, "t:End")});
 								break;
 							default:
-								exchWebService.commonFunctions.LOG("UNKNOWN CalendarItemType:"+xml2json.getTagValue(calendarItems[index], "t:CalendarItemType")+"\n");
+								exchWebService.commonFunctions.LOG("UNKNOWN CalendarItemType:"+xml2json.getTagValue(calItem, "t:CalendarItemType")+"\n");
 								break;
 						}
 					}

--- a/components/erFindCalendarItems.js
+++ b/components/erFindCalendarItems.js
@@ -242,25 +242,27 @@ exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue
 						}
 					}
 					calendarItems = null;
-//				if ((xml2json.getAttribute(rootFolder, "IncludesLastItemInRange") == "true") || (this.newStartDate === null) || (tmpDateObj.compare(this.rangeEnd) > 0)) {
+
+				// Return the result to be processed.
+				if (this.mCbOk) {
+					this.mCbOk(this, this.ids, occurences.slice());
+				}
+				// Clear data
+				this.recurringMasters = [];
+				this.occurrences = [];
+				this.occurrenceIds = [];
+				this.ids = [];
+
+				// Should continue or not
 				if ((xml2json.getAttribute(rootFolder, "IncludesLastItemInRange") == "true")) {
 					// We are done.
 					exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Includes last item in range.");
-					//exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Includes last item in range.\n\n");
+					this.isRunning = false;
 				}
 				else {
-					// We return the result to be processed.
 					exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Last item not in range so going for another run.");
-					//exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Last item not in range so going for another run.\n\n");
-					if (this.mCbOk) {
-						this.mCbOk(this, this.ids, occurrences.slice());
-					}
-					this.recurringMasters = [];
-					this.occurrences = [];
-					this.occurrenceIds = [];
-					this.ids = [];
 
-					this.execute(); 
+					this.execute();
 					return;
 				}
 			}
@@ -288,15 +290,6 @@ exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue
 		if (aError) {
 			this.onSendError(aExchangeRequest, aCode, aMsg);
 		}
-		else {
-			if (this.mCbOk) {
-				this.mCbOk(this, this.ids, occurrences.slice());
-			}
-			this.ids = null;
-			this.occurrences = null;
-			this.isRunning = false;
-		}
-		
 	},
 
 	onSendError: function _onSendError(aExchangeRequest, aCode, aMsg)

--- a/components/erFindCalendarItems.js
+++ b/components/erFindCalendarItems.js
@@ -95,8 +95,6 @@ function erFindCalendarItemsRequest(aArgument, aCbOk, aCbError, aListener)
 	this.occurrenceIds = [];
 	this.ids = [];
 
-	this.itemsFound = 0;
-	this.offset = 0;
 	this.isRunning = true;
 	this.execute();
 }
@@ -185,10 +183,6 @@ erFindCalendarItemsRequest.prototype = {
 		if (rm.length > 0) {
 			var rootFolder = xml2json.getTag(rm[0], "m:RootFolder");
 			if (rootFolder) {
-					//this.offset = xml2json.getAttribute(rootFolder, "IndexedPagingOffset");
-					//exchWebService.commonFunctions.LOG(" -- Next IndexedPagingOffset:"+this.offset+".");
-					//exchWebService.commonFunctions.LOG(" -- Next IndexedPagingOffset:"+this.offset+"\n");
-
 					// Process results.
 					var calendarItems = xml2json.XPath(rootFolder, "/t:Items/t:CalendarItem");
 					this.newStartDate = null;
@@ -205,7 +199,6 @@ erFindCalendarItemsRequest.prototype = {
 //		exchWebService.commonFunctions.LOG("  && this.newStartDate:"+this.newStartDate+"\n");
 						}
 
-						this.itemsFound++;
 						var uid = xml2json.getTagValue(calItem, "t:UID", "");
 
 /*exchWebService.commonFunctions.LOG("  ** title:"+xml2json.getTagValue(calItem, "t:Subject", "<NOP>")+"\n");
@@ -241,7 +234,7 @@ exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue
 								break;
 						}
 					}
-					calendarItems = null;
+				var itemsFound = calendarItems.length;
 
 				// Return the result to be processed.
 				if (this.mCbOk) {
@@ -252,15 +245,16 @@ exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue
 				this.occurrences = [];
 				this.occurrenceIds = [];
 				this.ids = [];
+				calendarItems = null;
 
 				// Should continue or not
 				if ((xml2json.getAttribute(rootFolder, "IncludesLastItemInRange") == "true")) {
 					// We are done.
-					exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Includes last item in range.");
+					exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Includes last item in range.");
 					this.isRunning = false;
 				}
 				else {
-					exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Last item not in range so going for another run.");
+					exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Last item not in range so going for another run.");
 
 					this.execute();
 					return;
@@ -271,6 +265,9 @@ exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue
 				aError = true;
 				aMsg = "No RootFolder found in FindItemResponse.";
 			}
+
+			// Ensure data can be cleared
+			rootFolder = null;
 		}
 		else {
 			aMsg = this.parent.getSoapErrorMsg(aResp);

--- a/components/erFindCalendarItems.js
+++ b/components/erFindCalendarItems.js
@@ -105,7 +105,7 @@ erFindCalendarItemsRequest.prototype = {
 
 	execute: function _execute()
 	{
-		//dump("erFindCalendarItemsRequest.execute\n");
+		//exchWebService.commonFunctions.LOG("erFindCalendarItemsRequest.execute\n");
 
 		var root = xml2json.newJSON();
 		var req = xml2json.addTag(root, "FindItem", "nsMessages", null);
@@ -154,7 +154,7 @@ erFindCalendarItemsRequest.prototype = {
 
 		this.parent.xml2json = true;
 
-		//dump("erFindCalendarItemsRequest.execute 2:"+String(this.parent.makeSoapMessage2(req))+"\n");
+		//exchWebService.commonFunctions.LOG("erFindCalendarItemsRequest.execute 2:"+String(this.parent.makeSoapMessage2(req))+"\n");
 
                 this.parent.sendRequest(this.parent.makeSoapMessage2(req), this.serverUrl);
 		req = null;
@@ -173,7 +173,7 @@ erFindCalendarItemsRequest.prototype = {
 		 * Occurrence for those masters that did not yet see any Exception.
 		 */
 		if (this.subject) {
-		 dump("erFindCalendarItemsRequest.onSendOk:"+xml2json.toString(aResp)+"\n");
+		 exchWebService.commonFunctions.LOG("erFindCalendarItemsRequest.onSendOk:"+xml2json.toString(aResp)+"\n");
 		}
 
 		var aError = false;
@@ -187,7 +187,7 @@ erFindCalendarItemsRequest.prototype = {
 			if (rootFolder) {
 					//this.offset = xml2json.getAttribute(rootFolder, "IndexedPagingOffset");
 					//exchWebService.commonFunctions.LOG(" -- Next IndexedPagingOffset:"+this.offset+".");
-					//dump(" -- Next IndexedPagingOffset:"+this.offset+"\n");
+					//exchWebService.commonFunctions.LOG(" -- Next IndexedPagingOffset:"+this.offset+"\n");
 
 					// Process results.
 					var calendarItems = xml2json.XPath(rootFolder, "/t:Items/t:CalendarItem");
@@ -201,16 +201,16 @@ erFindCalendarItemsRequest.prototype = {
 							offset.seconds = 1;
 							tmpDateObj.addDuration(offset);
 							this.newStartDate = convDate(tmpDateObj);
-//		dump("  && this.newStartDate:"+this.newStartDate+"\n");
+//		exchWebService.commonFunctions.LOG("  && this.newStartDate:"+this.newStartDate+"\n");
 						}
 
 						this.itemsFound++;
 						var uid = xml2json.getTagValue(calendarItems[index], "t:UID", "");
 
-/*dump("  ** title:"+xml2json.getTagValue(calendarItems[index], "t:Subject", "<NOP>")+"\n");
-dump("  ** Start:"+xml2json.getTagValue(calendarItems[index], "t:Start", "<NOP>")+"\n");
-dump("  ** End:"+xml2json.getTagValue(calendarItems[index], "t:End", "<NOP>")+"\n");
-dump("  ** CalendarItemType:"+xml2json.getTagValue(calendarItems[index], "t:CalendarItemType", "<NOP>")+"\n");*/
+/*exchWebService.commonFunctions.LOG("  ** title:"+xml2json.getTagValue(calendarItems[index], "t:Subject", "<NOP>")+"\n");
+exchWebService.commonFunctions.LOG("  ** Start:"+xml2json.getTagValue(calendarItems[index], "t:Start", "<NOP>")+"\n");
+exchWebService.commonFunctions.LOG("  ** End:"+xml2json.getTagValue(calendarItems[index], "t:End", "<NOP>")+"\n");
+exchWebService.commonFunctions.LOG("  ** CalendarItemType:"+xml2json.getTagValue(calendarItems[index], "t:CalendarItemType", "<NOP>")+"\n");*/
 
 						switch (xml2json.getTagValue(calendarItems[index], "t:CalendarItemType")) {
 							case "Occurrence" :
@@ -245,12 +245,12 @@ dump("  ** CalendarItemType:"+xml2json.getTagValue(calendarItems[index], "t:Cale
 				if ((xml2json.getAttribute(rootFolder, "IncludesLastItemInRange") == "true")) {
 					// We are done.
 					exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Includes last item in range.");
-					//dump("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Includes last item in range.\n\n");
+					//exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Includes last item in range.\n\n");
 				}
 				else {
 					// We return the result to be processed.
 					exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Last item not in range so going for another run.");
-					//dump("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Last item not in range so going for another run.\n\n");
+					//exchWebService.commonFunctions.LOG("erFindCalendarItems: retrieved:"+this.itemsFound+" items. TotalItemsInView:"+xml2json.getAttribute(rootFolder, "TotalItemsInView")+" items. Last item not in range so going for another run.\n\n");
 					if (this.mCbOk) {
 						var occurrenceList = [];
 						for (var index in this.occurrences) {
@@ -308,7 +308,7 @@ dump("  ** CalendarItemType:"+xml2json.getTagValue(calendarItems[index], "t:Cale
 
 	onSendError: function _onSendError(aExchangeRequest, aCode, aMsg)
 	{
-dump(" @@@ onSendError aCode:"+aCode+", aMsg:"+aMsg+" @@@\n");
+exchWebService.commonFunctions.LOG(" @@@ onSendError aCode:"+aCode+", aMsg:"+aMsg+" @@@\n");
 		this.isRunning = false;
 		if (this.mCbError) {
 			this.mCbError(this, aCode, aMsg);


### PR DESCRIPTION
Hello,

I was testing use of PagedItemView instead of CalendarItemView and after some tests, I think the best is to keep use of CalendarView instead of PagedItemView.

Indeed, the structure of the code of [mivExchangeCalendar.js](https://github.com/Ericsson/exchangecalendar/blob/master/interfaces/exchangeCalendar/mivExchangeCalendar.js) is designed to do call of erFindCalendarItems using time period (it passes as argument a range start and a range end).

Furthermore, I've read on [StackOverflow ](http://stackoverflow.com/questions/11999781/how-to-do-paging-with-exchange-web-services-calendarview) that CalendarView make easier to treat repeting calendar items.

Finally, it seems that this project has already tried to use PagedItemView in commit 46ee1c6c3045bde974c70ec3043b7e47e2d8e4fa but then it rolled back after commit f938988edc103723afba778be605dc0587f8e0d2 to solve issue 381 (the issue came from the original bug reporter I suppose and it is sadly not any more online).

So, I've written some improvements of current code and it is the content of this PR:

* Use javascript engine to copy arrays with the [slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice) method
* Remove some code duplication and make it simpler to read
* Replace dump function by log calls
* Clean useless code and variables which I supposed came from 46ee1c6c3045bde974c70ec3043b7e47e2d8e4fa

If you are Ok, I can also add a commit to fix the indentation too. It seems broken in the processing result loop.

Please let me know if you'd prefer pull requests on master or on ec-3.5 branch (I forgot to ask you with the last one).

See you,
Adrien