### PR TITLE
erFindContacts : offset management and callback arguments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,12 +12,12 @@ do
     case ${OPTION} in
         u) echo "update"  
 	cat defaults/preferences/update_enable.txt > defaults/preferences/update.js
- 	zip -r exchangecalendar-$version.xpi * -x \*.git \*.xpi \*.sh  update\*.txt
+ 	zip -r exchangecalendar-v$version.xpi * -x \*.git \*.xpi \*.sh  update\*.txt
 	exit
 	;;
         d) echo "no update" 
 	cat defaults/preferences/update_disable.txt > defaults/preferences/update.js
- 	zip -r exchangecalendar-$version.xpi * -x \*.git \*.xpi \*.sh  update\*.txt
+ 	zip -r exchangecalendar-v$version.xpi * -x \*.git \*.xpi \*.sh  update\*.txt
 	exit
 	;;
 	*) usage ;; 

--- a/chrome/content/calendar-summary-dialog.xul
+++ b/chrome/content/calendar-summary-dialog.xul
@@ -37,6 +37,8 @@
 <!DOCTYPE dialog [
     <!ENTITY % eventDialogDTD SYSTEM "chrome://calendar/locale/calendar-event-dialog.dtd">
     %eventDialogDTD;
+	<!ENTITY % summaryDialogDTD SYSTEM "chrome://exchangecalendar/locale/calendar-summary-dialog.dtd">
+    %summaryDialogDTD;
 ]>
 
 <?xul-overlay href="chrome://exchangecalendar/content/attachments-view.xul"?>
@@ -45,7 +47,7 @@
 	xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 
 <dialog id="calendar-summary-dialog" windowtype="Calendar:EventSummaryDialog"
-		buttons="accept,cancel" buttonlabelextra1="Forward invite"
+		buttons="accept,cancel" buttonlabelextra1="&forward.invite.label;"
 		ondialogextra1="tmpEventSummaryDialog.onForward();" persist="screenX screenY width height"
 		xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul">
 		
@@ -87,7 +89,7 @@
 		<box id="item-attendees" hidden="true" orient="vertical">
 
 			<spacer id="required-attendee-spacer" class="default-spacer" hidden="true"/>
-			<calendar-caption id="required-attendee-caption" label="Required Attendee"
+			<calendar-caption id="required-attendee-caption" label="&required.attendee.label;"
 			control="item-required-attendee-listbox" hidden="true"/>
 			<box orient="horizontal" id="item-required-attendee" hidden="true">
 				<spacer class="default-spacer"/>
@@ -104,7 +106,7 @@
 			</box>
 
 			<spacer id="optional-attendee-spacer" class="default-spacer" hidden="true"/>
-			<calendar-caption id="optional-attendee-caption" label="Optional Attendee"
+			<calendar-caption id="optional-attendee-caption" label="&optional.attendee.label;"
 			control="item-optional-attendee-listbox" hidden="true"/>
 			<box orient="horizontal" id="item-optional-attendee" hidden="true">
 				<spacer class="default-spacer"/>

--- a/components/erFindContacts.js
+++ b/components/erFindContacts.js
@@ -38,7 +38,7 @@ function erFindContactsRequest(aArgument, aCbOk, aCbError, aListener)
 
 	var self = this;
 
-	this.parent = new ExchangeRequest(aArgument, 
+	this.parent = new ExchangeRequest(aArgument,
 		function(aExchangeRequest, aResp) { self.onSendOk(aExchangeRequest, aResp);},
 		function(aExchangeRequest, aCode, aMsg) { self.onSendError(aExchangeRequest, aCode, aMsg);},
 		aListener);
@@ -65,12 +65,12 @@ erFindContactsRequest.prototype = {
 
 	execute: function _execute(offset)
 	{
-//		exchWebService.commonFunctions.LOG("erFindContactsRequest.execute\n");
+		//exchWebService.commonAbFunctions.logInfo("erFindContactsRequest.execute\n");
 
 		var req = exchWebService.commonFunctions.xmlToJxon('<nsMessages:FindItem xmlns:nsMessages="'+nsMessagesStr+'" xmlns:nsTypes="'+nsTypesStr+'"/>');
 		req.setAttribute("Traversal", "Shallow");
 
-		var itemShape = req.addChildTag("ItemShape", "nsMessages", null); 
+		var itemShape = req.addChildTag("ItemShape", "nsMessages", null);
 		itemShape.addChildTag("BaseShape", "nsTypes", "IdOnly");
 
 		// The IndexedPageItemView allows to request a certain range of contacts in the address book
@@ -104,15 +104,15 @@ erFindContactsRequest.prototype = {
 
 		this.parent.xml2jxon = true;
 
-		//exchWebService.commonFunctions.LOG("erFindContactsRequest.execute:"+String(this.parent.makeSoapMessage(req)));
+		//exchWebService.commonAbFunctions.logInfo("erFindContactsRequest.execute:"+String(this.parent.makeSoapMessage(req)));
 
-                this.parent.sendRequest(this.parent.makeSoapMessage(req), this.serverUrl);
+		this.parent.sendRequest(this.parent.makeSoapMessage(req), this.serverUrl);
 		req = null;
 	},
 
 	onSendOk: function _onSendOk(aExchangeRequest, aResp)
 	{
-		exchWebService.commonFunctions.LOG("erFindContactsRequest.onSendOk:"+String(aResp));
+		exchWebService.commonAbFunctions.logInfo("erFindContactsRequest.onSendOk:"+String(aResp));
 
 		var rm = aResp.XPath("/s:Envelope/s:Body/m:FindItemResponse/m:ResponseMessages/m:FindItemResponseMessage/m:ResponseCode");
 
@@ -136,7 +136,7 @@ erFindContactsRequest.prototype = {
 			var includesLastItemInRange = rootFolder[0].getAttribute("IncludesLastItemInRange", "true");
 
 			for each (var contact in rootFolder[0].XPath("/t:Items/t:Contact")) {
-				exchWebService.commonFunctions.LOG("erFindContactsRequest.contacts: id:"+contact.getAttributeByTag("t:ItemId", "Id")+", changekey:"+contact.getAttributeByTag("t:ItemId", "ChangeKey"));
+				exchWebService.commonAbFunctions.logInfo("erFindContactsRequest.contacts: id:"+contact.getAttributeByTag("t:ItemId", "Id")+", changekey:"+contact.getAttributeByTag("t:ItemId", "ChangeKey"));
 				this.contacts.push({Id: contact.getAttributeByTag("t:ItemId", "Id"),
 					  ChangeKey: contact.getAttributeByTag("t:ItemId", "ChangeKey"),
 					  name: contact.getTagValue("t:Subject"),

--- a/components/erFindContacts.js
+++ b/components/erFindContacts.js
@@ -131,10 +131,6 @@ erFindContactsRequest.prototype = {
 				return;
 			}
 
-			// These values are used to know if this is the last request (all items are received or not)
-			var totalItemsInView = rootFolder[0].getAttribute("TotalItemsInView", 0);
-			var includesLastItemInRange = rootFolder[0].getAttribute("IncludesLastItemInRange", "true");
-
 			for each (var contact in rootFolder[0].XPath("/t:Items/t:Contact")) {
 				exchWebService.commonAbFunctions.logInfo("erFindContactsRequest.contacts: id:"+contact.getAttributeByTag("t:ItemId", "Id")+", changekey:"+contact.getAttributeByTag("t:ItemId", "ChangeKey"));
 				this.contacts.push({Id: contact.getAttributeByTag("t:ItemId", "Id"),
@@ -150,11 +146,15 @@ erFindContactsRequest.prototype = {
 					  displayName: distlist.getTagValue("t:DisplayName")});
 			}
 
-			var offset = this.contacts.length + this.distlists.length + 1;
+			// RootFolder attributes received after a FindItem request:
+			// https://msdn.microsoft.com/EN-US/library/office/aa493859%28v=exchg.150%29.aspx
+			var totalItemsInView = rootFolder[0].getAttribute("TotalItemsInView", 0);
+			var includesLastItemInRange = rootFolder[0].getAttribute("IncludesLastItemInRange", "true");
+			var offset = rootFolder[0].getAttribute("IndexedPagingOffset", 0);
 
-			exchWebService.commonAbFunctions.logInfo("erFindContactsRequest.onSendOk Retrieved: "+offset+" contacts and distlists on a total of "+totalItemsInView+" items available in the view.");
+			exchWebService.commonAbFunctions.logInfo("erFindContactsRequest.onSendOk Retrieved: "+(this.distlists.length + this.contacts.length)+" contacts and distlists on a total of "+totalItemsInView+" items available in the view.");
 
-			if (includesLastItemInRange == true || offset >= totalItemsInView) {
+			if (includesLastItemInRange == "true") {
 				if (this.mCbOk) {
 					this.mCbOk(this, this.contacts, this.distlists);
 				}

--- a/components/erFindContacts.js
+++ b/components/erFindContacts.js
@@ -156,7 +156,7 @@ erFindContactsRequest.prototype = {
 
 			if (includesLastItemInRange == "true") {
 				if (this.mCbOk) {
-					this.mCbOk(this, this.contacts, this.distlists);
+					this.mCbOk(this, this.contacts.slice(), this.distlists.slice());
 				}
 				this.isRunning = false;
 				this.contacts = [];

--- a/install.rdf
+++ b/install.rdf
@@ -5,7 +5,7 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>exchangecalendar@extensions.1st-setup.nl</em:id>
-    <em:version>3.5.0-beta1</em:version>
+    <em:version>3.5.0</em:version>
 
     <em:targetApplication>
       <Description>

--- a/install.rdf
+++ b/install.rdf
@@ -5,7 +5,7 @@
 
   <Description about="urn:mozilla:install-manifest">
     <em:id>exchangecalendar@extensions.1st-setup.nl</em:id>
-    <em:version>3.5.0-beta0</em:version>
+    <em:version>3.5.0-beta1</em:version>
 
     <em:targetApplication>
       <Description>

--- a/locale/exchangecalendar/de/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/de/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required Attendee">
+<!ENTITY optional.attendee.label "Optional Attendee">

--- a/locale/exchangecalendar/en-US/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/en-US/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required Attendee">
+<!ENTITY optional.attendee.label "Optional Attendee">

--- a/locale/exchangecalendar/fr-FR/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/fr-FR/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required Attendee">
+<!ENTITY optional.attendee.label "Optional Attendee">

--- a/locale/exchangecalendar/ja-JP/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/ja-JP/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required Attendee">
+<!ENTITY optional.attendee.label "Optional Attendee">

--- a/locale/exchangecalendar/nl/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/nl/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required Attendee">
+<!ENTITY optional.attendee.label "Optional Attendee">

--- a/locale/exchangecalendar/ru/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/ru/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required Attendee">
+<!ENTITY optional.attendee.label "Optional Attendee">

--- a/locale/exchangecalendar/sv/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/sv/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required Attendee">
+<!ENTITY optional.attendee.label "Optional Attendee">

--- a/locale/exchangecalendar/tr/calendar-summary-dialog.dtd
+++ b/locale/exchangecalendar/tr/calendar-summary-dialog.dtd
@@ -1,0 +1,3 @@
+<!ENTITY forward.invite.label "Forward invite">
+<!ENTITY required.attendee.label "Required Attendee">
+<!ENTITY optional.attendee.label "Optional Attendee">


### PR DESCRIPTION
I've discovered that RootFolder exchange response contains the next offset to be used to complete synchronisation. This PR uses the response server to decide what and how to do next.

This PR modifies the way of giving back the contacts and dstribution list arrays to callback: it give a clone of arrays as done in erFindCalendarItems and clean their own copies after.

See you,
Adrien