### PR TITLE
Do a first sync only once in exchAbFolderDirectory and some javascript clean up

### DIFF
--- a/components/erExpandDL.js
+++ b/components/erExpandDL.js
@@ -107,16 +107,11 @@ erExpandDLRequest.prototype = {
 
 		var allMailboxes = new Array();
 		for each(var expansion in dlExpansion) {
+			// TODO Decide what to do with totalItemsInView and includesLastItem
+			//var totalItemsInView = expansion.getAttribute("TotalItemsInView", 0);
+			//var includesLastItem = expansion.getAttribute("IncludesLastItemInRange", "false");
 
-			var totalItemsInView = expansion.getAttribute("TotalItemsInView", 0);
-			var includesLastItem = expansion.getAttribute("IncludesLastItemInRange", "false");
-
-			var mailboxes = expansion.getTags("t:Mailbox");
-			for each(var mailbox in mailboxes) {
-				allMailboxes.push(mailbox);
-			}
-			mailboxes = null;
-		
+			allMailboxes = Array.concat(allMailboxes, expansion.getTags("t:Mailbox"));
 		}
 		dlExpansion = null;
 

--- a/components/erGetContacts.js
+++ b/components/erGetContacts.js
@@ -130,6 +130,8 @@ erGetContactsRequest.prototype = {
 		if (this.mCbOk) {
 			this.mCbOk(this, contacts);
 		}
+		rm = null;
+		contacts = null;
 		this.isRunning = false;
 	},
 

--- a/components/erGetContacts.js
+++ b/components/erGetContacts.js
@@ -125,12 +125,7 @@ erGetContactsRequest.prototype = {
 
 		var rm = aResp.XPath("/s:Envelope/s:Body/m:FindItemResponse/m:ResponseMessages/m:FindItemResponseMessage/m:ResponseCode");
 
-		var contacts = [];
-		var tmpList = aResp.XPath("/s:Envelope/s:Body/m:GetItemResponse/m:ResponseMessages/m:GetItemResponseMessage/m:Items/*");
-		for (var index in tmpList) {
-			contacts.push(tmpList[index]);
-		}
-		tmpList = null;
+		var contacts =  aResp.XPath("/s:Envelope/s:Body/m:GetItemResponse/m:ResponseMessages/m:GetItemResponseMessage/m:Items/*").slice();
 
 		if (this.mCbOk) {
 			this.mCbOk(this, contacts);

--- a/components/erResolveNames.js
+++ b/components/erResolveNames.js
@@ -127,15 +127,11 @@ erResolveNames.prototype = {
 			var resolutionsSets = rm[0].getTags("m:ResolutionSet");
 
 			for each(var resolutionsSet in resolutionsSets) {
+				// TODO Take into account TotalItemsInView and IncludesLastItemInRange
+				//var totalItemsInView = resolutionsSet.getAttribute("TotalItemsInView", 0);
+				//var includesLastItem = resolutionsSet.getAttribute("IncludesLastItemInRange", "false");
 
-				var totalItemsInView = resolutionsSet.getAttribute("TotalItemsInView", 0);
-				var includesLastItem = resolutionsSet.getAttribute("IncludesLastItemInRange", "false");
-
-				var resList = resolutionsSet.XPath("/t:Resolution");
-				for each(var resolution in resList) {
-					allResolutions.push(resolution);
-				}
-		
+				allResolutions = Array.concat(allResolutions, resolutionsSet.XPath("/t:Resolution"));
 			}
 			resolutionsSets = null;
 		}

--- a/components/erSyncContactsFolder.js
+++ b/components/erSyncContactsFolder.js
@@ -166,9 +166,7 @@ erSyncContactsFolderRequest.prototype = {
 				}
 			}
 
-			for each (var deleted in rm[0].XPath("/m:Changes/t:Delete")) {
-				this.deletions.contacts.push(deleted);
-			}
+			this.deletions.contacts = Array.concat(this.deletions.contacts, rm[0].XPath("/m:Changes/t:Delete"));
 
 			rm = null;
 
@@ -180,11 +178,17 @@ erSyncContactsFolderRequest.prototype = {
 				if (this.mCbOk) {
 					this.mCbOk(this, this.creations, this.updates, this.deletions, syncState);
 				}
+				this.creations = null;
+				this.updates = null;
+				this.deletions = null;
 				this.isRunning = false;
 			}
 		}
 		else {
 			rm = null;
+			this.creations = null;
+			this.updates = null;
+			this.deletions = null;
 			this.onSendError(aExchangeRequest, this.parent.ER_ERROR_SYNCFOLDERITEMS_UNKNOWN, "Error during erSyncContactsFolderRequest");
 			return;
 		}

--- a/interfaces/exchangeAddressBook/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
+++ b/interfaces/exchangeAddressBook/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
@@ -730,9 +730,11 @@ try {
 			else {
 				// Non query directories we set the refresh timer for
 				exchWebService.commonAbFunctions.logInfo("exchangeAbFolderDirectory: init. Going to do first sync. aURI:"+aURI+"\n");
-				this.syncFolder();  // First sync to initialize.
 
-			        let self = this;
+				// As we have no cache for address books, we always do a first sync on initialization
+				this.syncFolder();
+
+				let self = this;
 				let timerCallback = {
 					notify: function setTimeout_notify() {
 						self.syncFolder();
@@ -740,8 +742,6 @@ try {
 				};
 
 				this.pollTimer.initWithCallback(timerCallback, exchWebService.commonFunctions.safeGetIntPref(this.prefs, "pollinterval", 300, true) * 1000, this.pollTimer.TYPE_REPEATING_SLACK);
-
-				this.loadContactsFromExchange();
 			}
 
 
@@ -1392,13 +1392,6 @@ try {
 	{
 		exchWebService.commonAbFunctions.logInfo("exchangeAbFolderDirectory: syncFolderOK "+ this.dirName);
 
-		if (!this.syncState) {
-			exchWebService.commonAbFunctions.logInfo("syncFolderOK: First sync we are not going to use the data.");
-			this.syncState = syncState;
-			this.weAreSyncing = false;
-			return;
-		}
-
 		if ((creations.contacts.length > 0) || (updates.contacts.length > 0) || (deletions.contacts.length > 0)) {
 			this.addActivity(exchWebService.commonFunctions.getString("ExchangeContacts","syncFolderEventMessage",[creations.contacts.length, updates.contacts.length, deletions.contacts.length, this.dirName],"exchangecalendar"), "", erSyncContactsFolderRequest.argument.actionStart, Date.now())
 			exchWebService.commonAbFunctions.logInfo(exchWebService.commonFunctions.getString("ExchangeContacts","syncFolderEventMessage",[creations.contacts.length, updates.contacts.length, deletions.contacts.length, this.dirName],"exchangecalendar"));
@@ -1467,10 +1460,7 @@ try {
 		}
 
 		this.syncState = syncState;
-
-		if (newCards.length == 0) {
-			this.weAreSyncing = false;
-		}
+		this.weAreSyncing = false;
 	},
 
 	syncFolderError: function _syncFolderError(erSyncContactsFolderRequest, aCode, aMsg)
@@ -1484,14 +1474,9 @@ try {
 		exchWebService.commonAbFunctions.logInfo("exchangeAbFolderDirectory: contactsLoadOk2: contacts:"+aContacts.length);
 
 		for each(var contact in aContacts) {
-			//exchWebService.commonAbFunctions.logInfo("Contact card:"+contact.toString(),2);
 			exchWebService.commonAbFunctions.logInfo("exchangeAbFolderDirectory: new childCards:"+contact.getTagValue("t:DisplayName"));
 			this.ecUpdateCard(contact);
-
 		}
-
-		this.weAreSyncing = false;
-
 	},
 
 	addActivity: function _addActivity(aTitle, aText, aStartDate, aEndDate)

--- a/interfaces/exchangeAddressBook/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
+++ b/interfaces/exchangeAddressBook/exchangeAbFolderDirectory/exchangeAbFolderDirectory.js
@@ -438,9 +438,7 @@ exchangeAbFolderDirectory.prototype = {
 		var result = [];
 
 		if (this.distLists.length > 0) {
-			for each(var distList in this.distLists) {
-				result.push(distList);
-			}
+			result = this.distLists.slice();
 		}
 		return exchWebService.commonFunctions.CreateSimpleEnumerator(result);
 	},
@@ -1407,20 +1405,13 @@ try {
 		}
 
 		var newCards = [];
-		for each(var newCard in creations.contacts) {
-			//exchWebService.commonAbFunctions.logInfo("New Contact card:"+newCard.toString(),2);
-			newCards.push(newCard)
-		}
+		newCards = creations.contacts.slice();
+		newCards = Array.concat(newCards, updates.contacts);
 
-		for each(var updatedCard in updates.contacts) {
-			//exchWebService.commonAbFunctions.logInfo("Updated Contact card:"+updatedCard.toString(),2);
-			newCards.push(updatedCard)
-		}
-		
 		if (newCards.length > 0) {
 			var self = this;
 			this.addToQueue( erGetContactsRequest,
-							{user: this.user, 
+							{user: this.user,
 							 mailbox: this.mailbox,
 							 folderBase: this.folderBase,
 							 serverUrl: this.serverUrl,
@@ -1434,11 +1425,13 @@ try {
 		}
 	
 		for each(var deletedCard in deletions.contacts) {
+			var deletedId = deletedCard.getAttributeByTag("t:ItemId", "Id");
+			var deletedContact = this.contacts[deletedId];
 			//exchWebService.commonAbFunctions.logInfo("Deleted Contact card:"+deletedCard.toString(),2);
-			if (this.contacts[deletedCard.getAttributeByTag("t:ItemId", "Id")]) {
-				MailServices.ab.notifyDirectoryItemDeleted(this, this.contacts[deletedCard.getAttributeByTag("t:ItemId", "Id")]);
-				MailServices.ab.notifyDirectoryDeleted(this, this.contacts[deletedCard.getAttributeByTag("t:ItemId", "Id")]);
-				delete this.contacts[deletedCard.getAttributeByTag("t:ItemId", "Id")];
+			if (deletedContact) {
+				MailServices.ab.notifyDirectoryItemDeleted(this, deletedContact);
+				MailServices.ab.notifyDirectoryDeleted(this, deletedContact);
+				delete this.contacts[deletedId];
 			}
 		}
 


### PR DESCRIPTION
Hello,

I've noticed while debugging my address book that we were calling twice all contacts from the web service by two different mean:
- First we do a SyncFolder request
- Then we do a ContactsFindItem request

That's why I was my assumptions were not clear in bug report #398 .

This PR clean this situation by making only a SyncFolder request and using data from it.
I've decided to keep the SyncFolder request because this one give us a SyncState which will be used in the next synchronisation process.

Unfortunately, I have to admit, that I don't know why the function `loadContactsFromExchange()` were implemented, but I have thee feeling that today there's no reason to keep it in the code (only this code were using it).

Reviews and tests are welcome. I've tried with my exchange account and it works.

The other commits are code simplification by use of Javascript functions to handle variables.
I think that the javascript engine can do a smarter clone than pushing every elements of an array into another.

Regards,
Adrien
