### PR TITLE
Fix: The shared folder/folder id can also be a task list

### DIFF
--- a/chrome/content/exchangeSettingsOverlay.js
+++ b/chrome/content/exchangeSettingsOverlay.js
@@ -408,7 +408,7 @@ exchSettingsOverlay.prototype = {
 	{
 		this.globalFunctions.LOG("exchWebServicesGetFolderOK: aFolderID:"+aFolderID+", aChangeKey:"+aChangeKey+", aFolderClass:"+aFolderClass);
 
-		if (aFolderClass == "IPF.Appointment") {
+		if (aFolderClass == "IPF.Appointment" || aFolderClass == "IPF.Task") {
 			this.exchWebServicesgFolderID = aFolderID;
 			this.exchWebServicesgChangeKey = aChangeKey;
 			this.gexchWebServicesDetailsChecked = true;


### PR DESCRIPTION
If another user shares a task list with you, then you can add the task list through the Folder ID.
Therefore the folderClass can also be an `IPF.Task`

The rest of the plugin still works since calendar and tasks are the same.