### PR TITLE
Prevent global indexing from being enabled

### DIFF
--- a/defaults/preferences/debug.js
+++ b/defaults/preferences/debug.js
@@ -14,5 +14,4 @@ pref("extensions.extras.LowestIcon", "chrome://exchangecalendar-common/skin/imag
 pref("extensions.extras.ShadeHigh", true);
 pref("extensions.extras.ShadeLow", false); 
 pref("calendar.timezone.local.auto", true ); 
-pref("extensions.1st-setup.others.warnAboutPrereleaseVersion", true); 
-user_pref("mailnews.database.global.indexer.enabled", true); 
+pref("extensions.1st-setup.others.warnAboutPrereleaseVersion", true);


### PR DESCRIPTION
The global indexer is enabled as soon as this extension is installed, even if the user has disabled the indexer. The add-on will keep enabling the indexer every time Thunderbird starts.

Fixes #425 
