### PR TITLE
Add ability to manually disable / enable offline Exchange cache

### DIFF
--- a/chrome/content/calendar-properties-dialog.xul
+++ b/chrome/content/calendar-properties-dialog.xul
@@ -49,8 +49,7 @@
 				align="center">
 				<spacer/>
 				<checkbox id="exchange-cache"
-					hidden="true"
-					label="exchange-cache" 
+					label="Enable Offline Exchange Cache"
 					oncommand="return tmpChangeCalendarProperties.changeCachePref();"/>
 			</row>
 		     

--- a/chrome/content/exchangeSettings.xul
+++ b/chrome/content/exchangeSettings.xul
@@ -306,8 +306,8 @@
 						<caption label="Details:" />
 						<vbox>
 							<hbox>
-								<checkbox label="Cache" id="exchWebService-offlineCacheproperties-cacheState"
-									command="exchWebService_cmd_offlineCache" disabled="true"/>
+								<checkbox label="Enable Offline Cache" id="exchWebService-offlineCacheproperties-cacheState"
+									command="exchWebService_cmd_offlineCache" />
 							</hbox>
 						</vbox>
 						<vbox id="exchWebService-offlineCacheproperties-detaisvbox" collapsed="true">					


### PR DESCRIPTION
There seem to be ongoing issues with performance when offline caching is enabled (see for example  #437 and #507).

I do not understand why the ability to disable this feature is not available to users:
1. The offline cache is enabled by default at startup (mivExchangeCalendar.js:664)
2. The "Cache" checkbox on the EWS Calendar and Mail settings  -> Offline Caching dialog is disabled and greyed out.
3. The "exchange-cache" checkbox on the Edit Calendar dialog is hidden completely.

This commit enables both checkboxes, and makes their labels consistent (""Enable Offline Exchange Cache").

I can report a huge increase in performance when the offline cache is disabled.  Thunderbird was virtually unusable with EWS enabled (symptoms like those described in #437 and #507), but with the offline cache disabled it works quite well.  True, having calendar events visible while offline would be nice, but it's not essential for me, whereas a working Thunderbird is.  And users should at least have the option to enable and disable the cache at will.
